### PR TITLE
luci-app-3ginfo-lite typo - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Substeps:
 2. Update opkg and install the following packages:
     - luci-app-modemband
        - Allows easy adjustment for what cellular bands the modem should search for
-    - luci-app-3ginfo
+    - luci-app-3ginfo-lite
        - Give basic information about the current cellular connection
     - luci-app-atcommands
        - Allows for easy sending of AT commands to the modem


### PR DESCRIPTION
luci-app-3ginfo package doesn't exist in 4IceG's repo, changed it to luci-app-3ginfo-lite
Probably a typo :).